### PR TITLE
Update composer require block to allow Laravel 5.2.13+

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # eloquent-uuid
-An Eloquent UUID Trait to use with Laravel 5.1.
+An Eloquent UUID Trait to use with Laravel 5.1 or Laravel 5.2.13+.
 
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/hyperium/hyper/master/LICENSE)
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "alsofronie/eloquent-uuid",
     "description": "A Laravel Eloquent Model trait for using UUID's as primary keys",
     "require": {
-        "laravel/framework": "5.1.*",
+        "laravel/framework": "5.1.* || ^5.2.13",
         "webpatser/laravel-uuid": "2.*"
     },
     "require-dev": {


### PR DESCRIPTION
A [PR](https://github.com/laravel/framework/pull/12067) was accepted into the Laravel framework which fixed the issues that broke eloquent-uuid and was included in the tag 5.2.13.

I have updated the composer require block to allow this version of Laravel to be used with eloquent-uuid.
