### PR TITLE
Fixed traits to have bootUuidModelTrait(), bootUuid32ModelTrait() and…

### DIFF
--- a/src/Uuid32ModelTrait.php
+++ b/src/Uuid32ModelTrait.php
@@ -26,9 +26,8 @@ trait Uuid32ModelTrait
      * This function overwrites the default boot static method of Eloquent models. It will hook
      * the creation event with a simple closure to insert the UUID
      */
-    public static function boot()
+    public static function bootUuid32ModelTrait()
     {
-        parent::boot();
         static::creating(function ($model) {
 
             // This is necessary because on \Illuminate\Database\Eloquent\Model::performInsert

--- a/src/UuidBinaryModelTrait.php
+++ b/src/UuidBinaryModelTrait.php
@@ -25,9 +25,8 @@ trait UuidBinaryModelTrait
      * This function overwrites the default boot static method of Eloquent models. It will hook
      * the creation event with a simple closure to insert the UUID
      */
-    public static function boot()
+    public static function bootUuidBinaryModelTrait()
     {
-        parent::boot();
         static::creating(function ($model) {
 
             // This is necessary because on \Illuminate\Database\Eloquent\Model::performInsert

--- a/src/UuidModelTrait.php
+++ b/src/UuidModelTrait.php
@@ -25,9 +25,8 @@ trait UuidModelTrait
      * This function overwrites the default boot static method of Eloquent models. It will hook
      * the creation event with a simple closure to insert the UUID
      */
-    public static function boot()
+    public static function bootUuidModelTrait()
     {
-        parent::boot();
         static::creating(function ($model) {
 
             // This is necessary because on \Illuminate\Database\Eloquent\Model::performInsert


### PR DESCRIPTION
… bootUuidBinaryModelTrait() to avoid issue where the model event created() was being called before creating() in a model's boot() function: http://www.archybold.com/blog/post/booting-eloquent-model-traits
