### PR TITLE
UUID is only generated when not set manually.

### DIFF
--- a/src/Uuid32ModelTrait.php
+++ b/src/Uuid32ModelTrait.php
@@ -29,13 +29,15 @@ trait Uuid32ModelTrait
     public static function bootUuid32ModelTrait()
     {
         static::creating(function ($model) {
-
-            // This is necessary because on \Illuminate\Database\Eloquent\Model::performInsert
-            // will not check for $this->getIncrementing() but directly for $this->incrementing
-            $model->incrementing = false;
-            $uuidVersion = (!empty($model->uuidVersion) ? $model->uuidVersion : 4);   // defaults to 4
-            $uuid = Uuid::generate($uuidVersion);
-            $model->attributes[$model->getKeyName()] = str_replace('-', '', $uuid->string);
+            // Only generate UUID if it wasn't set by already.
+            if (!isset($model->attributes[$model->getKeyName()])) {
+                // This is necessary because on \Illuminate\Database\Eloquent\Model::performInsert
+                // will not check for $this->getIncrementing() but directly for $this->incrementing
+                $model->incrementing = false;
+                $uuidVersion = (!empty($model->uuidVersion) ? $model->uuidVersion : 4);   // defaults to 4
+                $uuid = Uuid::generate($uuidVersion);
+                $model->attributes[$model->getKeyName()] = str_replace('-', '', $uuid->string);
+            }
         }, 0);
     }
 }

--- a/src/UuidBinaryModelTrait.php
+++ b/src/UuidBinaryModelTrait.php
@@ -28,12 +28,15 @@ trait UuidBinaryModelTrait
     public static function bootUuidBinaryModelTrait()
     {
         static::creating(function ($model) {
-            // This is necessary because on \Illuminate\Database\Eloquent\Model::performInsert
-            // will not check for $this->getIncrementing() but directly for $this->incrementing
-            $model->incrementing = false;
-            $uuidVersion = (!empty($model->uuidVersion) ? $model->uuidVersion : 4);   // defaults to 4
-            $uuid = Uuid::generate($uuidVersion);
-            $model->attributes[$model->getKeyName()] = (property_exists($model, 'uuidOptimization') && $model::$uuidOptimization ? $model::toOptimized($uuid->string) : $uuid->bytes);
+            // Only generate UUID if it wasn't set by already.
+            if (!isset($model->attributes[$model->getKeyName()])) {
+                // This is necessary because on \Illuminate\Database\Eloquent\Model::performInsert
+                // will not check for $this->getIncrementing() but directly for $this->incrementing
+                $model->incrementing = false;
+                $uuidVersion = (!empty($model->uuidVersion) ? $model->uuidVersion : 4);   // defaults to 4
+                $uuid = Uuid::generate($uuidVersion);
+                $model->attributes[$model->getKeyName()] = (property_exists($model, 'uuidOptimization') && $model::$uuidOptimization ? $model::toOptimized($uuid->string) : $uuid->bytes);
+            }
         }, 0);
     }
 

--- a/src/UuidModelTrait.php
+++ b/src/UuidModelTrait.php
@@ -28,13 +28,15 @@ trait UuidModelTrait
     public static function bootUuidModelTrait()
     {
         static::creating(function ($model) {
-
-            // This is necessary because on \Illuminate\Database\Eloquent\Model::performInsert
-            // will not check for $this->getIncrementing() but directly for $this->incrementing
-            $model->incrementing = false;
-            $uuidVersion = (!empty($model->uuidVersion) ? $model->uuidVersion : 4);   // defaults to 4
-            $uuid = Uuid::generate($uuidVersion);
-            $model->attributes[$model->getKeyName()] = $uuid->string;
+            // Only generate UUID if it wasn't set by already.
+            if (!isset($model->attributes[$model->getKeyName()])) {
+                // This is necessary because on \Illuminate\Database\Eloquent\Model::performInsert
+                // will not check for $this->getIncrementing() but directly for $this->incrementing
+                $model->incrementing = false;
+                $uuidVersion = (!empty($model->uuidVersion) ? $model->uuidVersion : 4);   // defaults to 4
+                $uuid = Uuid::generate($uuidVersion);
+                $model->attributes[$model->getKeyName()] = $uuid->string;
+            }
         }, 0);
     }
 }


### PR DESCRIPTION
Let the developer set the ID manually (don't overwrite it in the `created` listener).
Use case: You might want to generate UUID's manually if the Model creation is deferred to a queued Job. 