### PR TITLE
Un-hardcode 'id', id_dashed_string attribute and fromJson fix

### DIFF
--- a/src/UuidBinaryModelTrait.php
+++ b/src/UuidBinaryModelTrait.php
@@ -29,13 +29,14 @@ trait UuidBinaryModelTrait
     {
         static::creating(function ($model) {
             // Only generate UUID if it wasn't set by already.
-            if (!isset($model->attributes[$model->getKeyName()])) {
+            $key = $model->getKeyName();
+            if (!isset($model->attributes[$key])) {
                 // This is necessary because on \Illuminate\Database\Eloquent\Model::performInsert
                 // will not check for $this->getIncrementing() but directly for $this->incrementing
                 $model->incrementing = false;
                 $uuidVersion = (!empty($model->uuidVersion) ? $model->uuidVersion : 4);   // defaults to 4
                 $uuid = Uuid::generate($uuidVersion);
-                $model->attributes[$model->getKeyName()] = (property_exists($model, 'uuidOptimization') && $model::$uuidOptimization ? $model::toOptimized($uuid->string) : $uuid->bytes);
+                $model->attributes[$key] = (property_exists($model, 'uuidOptimization') && $model::$uuidOptimization ? $model::toOptimized($uuid->string) : $uuid->bytes);
             }
         }, 0);
     }
@@ -46,8 +47,9 @@ trait UuidBinaryModelTrait
      */
     public function getIdStringAttribute()
     {
+        $key = $this->getKeyName();
         return (property_exists($this, 'uuidOptimization') && $this::$uuidOptimization)
-            ? self::toNormal($this->attributes['id']) : bin2hex($this->attributes['id']);
+            ? self::toNormal($this->attributes[$key]) : bin2hex($this->attributes[$key]);
     }
 
     /**
@@ -58,13 +60,14 @@ trait UuidBinaryModelTrait
      */
     public static function find($id, $columns = array('*'))
     {
+        $key = (new static)->getKeyName();
         if (ctype_print($id)) {
             $idFinal = (property_exists(static::class, 'uuidOptimization') && static::$uuidOptimization)
             ? self::toOptimized($id) : hex2bin($id);
 
-            return static::where('id', '=', $idFinal)->first($columns);
+            return static::where($key, '=', $idFinal)->first($columns);
         } else {
-            return parent::where('id', '=', $id)->first($columns);
+            return parent::where($key, '=', $id)->first($columns);
         }
     }
 
@@ -76,13 +79,14 @@ trait UuidBinaryModelTrait
      */
     public static function findOrFail($id, $columns = array('*'))
     {
+        $key = (new static)->getKeyName();
         if (ctype_print($id)) {
             $idFinal = (property_exists(static::class, 'uuidOptimization') && static::$uuidOptimization)
             ? self::toOptimized($id) : hex2bin($id);
 
-            return static::where('id', '=', $idFinal)->firstOrFail($columns);
+            return static::where($key, '=', $idFinal)->firstOrFail($columns);
         } else {
-            return parent::where('id', '=', $id)->firstOrFail($columns);
+            return parent::where($key, '=', $id)->firstOrFail($columns);
         }
     }
 

--- a/src/UuidBinaryModelTrait.php
+++ b/src/UuidBinaryModelTrait.php
@@ -145,11 +145,11 @@ trait UuidBinaryModelTrait
     public function fromJson($json, $asObject = false)
     {
         $useOptimization = !empty($this::$uuidOptimization);
-	$mixed = parent::fromJson($json, $asObject);
+        $mixed = parent::fromJson($json, $asObject);
         $key = $this->getKeyName();
-        if ($asObject) {
+        if ($asObject && property_exists($mixed, $key)) {
             $mixed->{$key} = static::toOptimized($mixed->{$key});
-        } else {
+        } elseif (array_key_exists($key, $mixed)) {
             $mixed[$key] = static::toOptimized($mixed[$key]);
         }
 

--- a/src/UuidBinaryModelTrait.php
+++ b/src/UuidBinaryModelTrait.php
@@ -53,6 +53,21 @@ trait UuidBinaryModelTrait
     }
 
     /**
+     * Gets the binary field as string ($model->id_dashed_string) with dashes
+     * @return string The string representation of the binary field.
+     */
+    public function getIdDashedStringAttribute()
+    {
+        $uuid = $this->getIdStringAttribute();
+
+        return substr($uuid, 0, 8) . '-' .
+            substr($uuid, 8, 4) . '-' .
+            substr($uuid, 12, 4) . '-' .
+            substr($uuid, 16, 4) . '-' .
+            substr($uuid, 20);
+    }
+
+    /**
      * Modified find static function to accept both string and binary versions of uuid
      * @param  mixed $id       The id (binary or hex string)
      * @param  array $columns  The columns to be returned (defaults to *)


### PR DESCRIPTION
Changes:

1. Remove hardcoded 'id' and instead use the dynamic primary key to make this work with custom named primary keys
2. Add a helper id_dashed_string attribute for convenience
3. In fromJson it was attempting to set the primary key even when the primary key is not set on the value we are casting.