### PR TITLE
Alias `dev-master` branch to a `1.0.x-dev` version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,5 +25,10 @@
         "psr-4": {
             "Alsofronie\\Uuid\\": "src/"
         }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
     }
 }


### PR DESCRIPTION
There is something wrong with the latest tagged version (`1.0.9`) but relying on a `dev-master` dependency [is not a good idea](https://lornajane.net/posts/2015/relying-on-a-dev-master-dependency-in-composer).