### PR TITLE
Fix UTF-8 string issues

### DIFF
--- a/src/UuidBinaryModelTrait.php
+++ b/src/UuidBinaryModelTrait.php
@@ -125,7 +125,7 @@ trait UuidBinaryModelTrait
             elseif (is_object($value) && method_exists($value, 'toArray')) {
                 $array[$key] = $value->toArray();
             }
-            elseif (is_string($value) && !ctype_print($value)) {
+            elseif (is_string($value) && mb_detect_encoding($value) === false) {//mb_detect_encoding will return false if $value is a binary type
                 $array[$key] = $useOptimization ? self::toNormal($value) : bin2hex($value);
             }
         }


### PR DESCRIPTION
The `ctype_print` could give a false positive if the string contains special UTF-8 characters.

For example a basic `User` model with a username field containing `François` or `Ramón`. Before the PR this would be wrongly converted to a hex string.
