### PR TITLE
Set primary key type to string.

### DIFF
--- a/src/Uuid32ModelTrait.php
+++ b/src/Uuid32ModelTrait.php
@@ -23,6 +23,16 @@ trait Uuid32ModelTrait
     }
 
     /**
+     * This function is used internally by Eloquent models to set the data type for the primary key.
+     * 
+     * @return string Always string
+     */
+    public function getkeyType()
+    {
+        return 'string';
+    }
+
+    /**
      * This function overwrites the default boot static method of Eloquent models. It will hook
      * the creation event with a simple closure to insert the UUID
      */

--- a/src/UuidModelTrait.php
+++ b/src/UuidModelTrait.php
@@ -22,6 +22,16 @@ trait UuidModelTrait
     }
 
     /**
+     * This function is used internally by Eloquent models to set the data type for the primary key.
+     * 
+     * @return string Always string
+     */
+    public function getkeyType()
+    {
+        return 'string';
+    }
+
+    /**
      * This function overwrites the default boot static method of Eloquent models. It will hook
      * the creation event with a simple closure to insert the UUID
      */


### PR DESCRIPTION
Relationships are loaded with the type 'int' when using the "with" (eager loading) method in Laravel 6. To fix this the type has be set to 'string'.